### PR TITLE
chore: Tailwind CSS v4 migration cleanup

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,21 +4,14 @@
   "extends": [
     "next/core-web-vitals",
     "next/typescript",
-    "prettier",
-    "plugin:tailwindcss/recommended"
+    "prettier"
   ],
-  "plugins": ["tailwindcss"],
   "rules": {
     "@next/next/no-html-link-for-pages": "off",
-    "tailwindcss/no-custom-classname": "off",
     "@typescript-eslint/no-empty-object-type": "off",
     "@typescript-eslint/no-unused-vars": "warn"
   },
   "settings": {
-    "tailwindcss": {
-      "callees": ["cn"],
-      "config": "tailwind.config.js"
-    },
     "next": {
       "rootDir": ["./"]
     }

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,14 +5,14 @@
 ```bash
 pnpm dev        # Start dev server with Turbopack (http://localhost:3000)
 pnpm build      # Production build
-pnpm lint       # ESLint + Tailwind lint
+pnpm lint       # ESLint
 ```
 
 There are no tests in this project.
 
 ## Architecture
 
-This is a **Next.js 15 App Router** landing site using React 19, TypeScript, Tailwind CSS v3, and shadcn/ui primitives.
+This is a **Next.js 16 App Router** landing site using React 19, TypeScript, Tailwind CSS v4, and shadcn/ui primitives.
 
 - **`app/`** — App Router entrypoint. `layout.tsx` wraps all pages with `ThemeProvider`, the `Header`, and the `Analytics` component. `page.tsx` is the only route.
 - **`components/ui/`** — Reusable UI primitives (Button, DropdownMenu, Header, Link, MobileNav, ModeToggle). These follow the shadcn/ui pattern: Radix UI primitives styled with Tailwind via `cn()`.
@@ -24,7 +24,8 @@ This is a **Next.js 15 App Router** landing site using React 19, TypeScript, Tai
 ## Key Conventions
 
 - **Path alias `@/`** maps to the repo root. Always use `@/` imports (e.g. `@/components/ui/button`, `@/config/site`).
-- **`cn()` for class merging** — always use `cn()` from `@/lib/utils` for any conditional or merged Tailwind classes; ESLint is configured to recognize it as a Tailwind callsite.
+- **Tailwind CSS v4** — No `tailwind.config.ts`; all theme customisation lives in `styles/globals.css` via `@theme inline {}`. Animations come from `tw-animate-css` (imported in `globals.css`). PostCSS is configured via `@tailwindcss/postcss`.
+- **`cn()` for class merging** — always use `cn()` from `@/lib/utils` for any conditional or merged Tailwind classes.
 - **`@/components/ui/link`** — Use this custom `LinkWrapper` instead of `next/link` or `<a>` directly. It auto-detects internal (`/`), anchor (`#`), and external links, adding `target="_blank" rel="noopener noreferrer"` for external ones.
 - **Dark mode** uses the `class` strategy (via `next-themes`). Use `dark:` Tailwind variants; the toggle in the header switches `light` / `dark` / `system`.
 - **Prettier** enforces: no semis, single quotes, 100-char print width, `es5` trailing commas. Import order is auto-sorted by `@ianvs/prettier-plugin-sort-imports` — react → next → third-party → internal (`@/`) → relative.


### PR DESCRIPTION
## Summary

Tailwind CSS v4 packages were already migrated via Dependabot PRs (#200, #201), but this cleanup was still needed:

- **Removes dead `eslint-plugin-tailwindcss` references** from `.eslintrc.json` — the package was dropped as part of the v4 migration (v4 has no `tailwind.config.js`, which the plugin required)
- **Updates `copilot-instructions.md`** to reflect the v4 stack: no `tailwind.config.ts`, `tw-animate-css` instead of `tailwindcss-animate`, PostCSS via `@tailwindcss/postcss`, theme config in `globals.css`

## Related
- Next.js 16 upgrade + ESLint flat config migration coming in a follow-up PR